### PR TITLE
Change auth response

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -38,7 +38,7 @@ class AuthController {
     );
 
     //Send the jwt in the response
-    response.send(token);
+    response.send({"token": token});
   };
 
   static changePassword = async (request: Request, response: Response) => {


### PR DESCRIPTION
This PR simply changes the auth endpoint reponse to be a json object instead of plain text. In this way, the front-end is able to retrieve it in a simple way.